### PR TITLE
Bugfix, use property access_mode

### DIFF
--- a/pyvcontrol/viControl.py
+++ b/pyvcontrol/viControl.py
@@ -94,7 +94,7 @@ class viControl:
         # sends a read command and gets the response.
 
         vc = viCommand(cmdname)
-        if not vc.write:
+        if vc.access_mode != 'write':
             raise viControlException(f'command {cmdname} cannot be written')
 
         # create viData object


### PR DESCRIPTION
execWriteCmd tries to use viCommand.write property, which was replaced by viCommand.access_mode